### PR TITLE
Adding tooltips to display type and description on the query builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "devDependencies": {
-    "react-scripts": "0.6.1"
+    "react-scripts": "0.6.1",
+    "surge": "^0.18.0"
   },
   "dependencies": {
     "babel-runtime": "^6.11.6",
@@ -28,6 +29,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "deploy": "npm run build && surge -p ./build -d wpconsole.surge.sh"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-input-autosize": "^1.1.0",
     "react-json-tree": "^0.10.0",
     "react-redux": "^4.4.5",
+    "react-tooltip": "^3.2.1",
     "redux": "^3.6.0",
     "redux-thunk": "^2.1.0",
     "superagent": "^2.3.0",

--- a/src/api/core.js
+++ b/src/api/core.js
@@ -112,9 +112,7 @@ const parseEndpoints = data => {
         Object.keys(rawEndpoint.args).forEach(key => {
           const arg = rawEndpoint.args[key];
           query[key] = {
-            description: {
-              view: arg.description
-            }
+            description: arg.description
           };
         });
 

--- a/src/app.css
+++ b/src/app.css
@@ -1,5 +1,6 @@
 body {
   margin: 0;
+  padding: 0;
   font-family: "Open Sans", sans-serif;
   font-size: 16px;
   line-height: 1;

--- a/src/components/lookup-container/index.js
+++ b/src/components/lookup-container/index.js
@@ -41,18 +41,25 @@ class LookupContainer extends Component {
   };
 
   renderEndpointPath() {
-    const { pathParts } = this.props;
+    const { pathParts, endpoint } = this.props;
     const getParamValue = param => this.props.pathValues[param] ? this.props.pathValues[param] : '';
 
-    return pathParts.map((part, index) =>
-      part[0] === '$'
-        ? <UrlPart key={ index }
+    return pathParts.map((part, index) => {
+      if (part[0] !== '$') {
+        return <div key={ index } className="url-segment">{ part }</div>
+      }
+
+      const pathParameter = endpoint.request.path[part];
+
+      return (
+        <UrlPart key={ index }
             value={ getParamValue(part) }
-            defaultValue={ part }
+            name={ part }
             onChange={ event => this.props.updatePathValue(part, event.target.value) }
+            parameter={ pathParameter }
             autosize />
-        : <div key={ index } className="url-segment">{ part }</div>
-    )
+        );
+    });
   }
 
   render() {

--- a/src/components/lookup-container/style.css
+++ b/src/components/lookup-container/style.css
@@ -28,7 +28,7 @@
   align-self: auto;
 }
 
-.lookup-container .parts div {
+.lookup-container .parts > div {
   font-size: 16px;
   font-family: Inconsolata, monospace;
   padding: 3px 1px 3px 1px;

--- a/src/components/param-builder/index.js
+++ b/src/components/param-builder/index.js
@@ -2,6 +2,8 @@ import React from 'react';
 
 import './style.css';
 
+import ParamTooltip from '../param-tooltip';
+
 const ParamBuilder = ({ title, params, values = {}, onChange }) => {
   const hasParams = !! params && Object.keys(params).length > 0;
 
@@ -11,14 +13,22 @@ const ParamBuilder = ({ title, params, values = {}, onChange }) => {
       { hasParams && <div className="scroller">
           <table>
             <tbody>
-              { Object.keys(params).map(paramKey =>
-                  <tr key={ paramKey }>
-                    <th>{ paramKey }</th>
-                    <td>
-                      <input type="text" value={ values[paramKey] || '' }
-                        onChange={ event => onChange(paramKey, event.target.value) } />
-                    </td>
-                  </tr>
+              { Object.keys(params).map(paramKey => {
+                  const parameter = params[paramKey];
+                  return (
+                    <tr key={ paramKey }>
+                      <th>{ paramKey }</th>
+                      <td>
+                        <div>
+                          <input type="text" value={ values[paramKey] || '' }
+                            data-tip data-for={ `param-${paramKey}` }
+                            onChange={ event => onChange(paramKey, event.target.value) } />
+                          <ParamTooltip parameter={ parameter } id={ `param-${paramKey}` } name={paramKey} position="right" />
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                }
               )}
             </tbody>
           </table>

--- a/src/components/param-tooltip/index.js
+++ b/src/components/param-tooltip/index.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import ReactTooltip from 'react-tooltip';
+import { isPlainObject } from 'lodash';
+
+import './style.css';
+
+const ParamTooltip = ({ parameter, id, name, position = 'bottom' }) => {
+  return (
+    <ReactTooltip id={ id } place={ position } effect="solid" class="param-tooltip">
+      <header>
+        <code>{ name }</code>
+        <em>{ parameter.type }</em>
+      </header>
+      <ul>
+        { isPlainObject(parameter.description)
+            ? Object.keys(parameter.description).map(key => (
+                <li key={ key }>
+                  <code>{ key }</code>
+                  <span>{ parameter.description[key] }</span>
+                </li>
+              ))
+            : <li><span>{ parameter.description }</span></li>
+        }
+      </ul>
+    </ReactTooltip>
+  );
+};
+
+export default ParamTooltip;

--- a/src/components/param-tooltip/style.css
+++ b/src/components/param-tooltip/style.css
@@ -1,0 +1,36 @@
+.param-tooltip header {
+  position: relative;
+  padding: 8px;
+  z-index: 1;
+}
+
+.param-tooltip code {
+    color: hsl(0,0%,100%);
+    margin-right: 10px;
+    display: inline-block;
+}
+
+.param-tooltip em {
+  color: hsl(195,75%,100%);
+  display: inline-block;
+  float: right;
+}
+
+.param-tooltip ul {
+  position: relative;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  z-index: 1;
+}
+
+.param-tooltip ul code {
+  color: hsl(195,75%,60%);
+}
+
+.param-tooltip li {
+  padding: 8px;
+  border-top: 1px solid hsla(0,0%,100%,0.1);
+  max-width: 300px;
+  line-height: 1.3em;
+}

--- a/src/components/url-part/index.js
+++ b/src/components/url-part/index.js
@@ -3,16 +3,25 @@ import AutosizeInput from 'react-input-autosize';
 
 import './style.css';
 
+import ParamTooltip from '../param-tooltip';
+
 const UrlPart = props => {
-  const { autosize = false, defaultValue = '', value, ...remainingProps } = props;
+  const { parameter = false, autosize = false, name = '', value, ...remainingProps } = props;
 
   if (autosize) {
-    return <AutosizeInput className="url-part" value={ value } placeholder={ defaultValue } { ...remainingProps }
-      inputStyle={{ fontSize: 14 }}/>
+
+    return <div className="url-part">
+      <AutosizeInput value={ value }
+        placeholder={ name }
+        inputStyle={{ fontSize: 14 }}
+        data-tip data-for={ `url-part-${name}` }
+        { ...remainingProps } />
+      { parameter && <ParamTooltip parameter={ parameter } id={ `url-part-${name}` } name={name} /> }
+    </div>
   }
 
   return (
-    <input value={value} className="url-part" placeholder={ defaultValue } { ...remainingProps } />
+      <input value={value} className="url-part" { ...remainingProps } />
   );
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,0 @@
-body {
-  margin: 0;
-  padding: 0;
-  font-family: sans-serif;
-}

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './app';
-import './index.css';
 
 ReactDOM.render(
   <App />,

--- a/src/state/request/selectors.js
+++ b/src/state/request/selectors.js
@@ -32,6 +32,7 @@ export const getCompleteQueryUrl = state => {
   const queryString = Object.keys(queryParams).length === 0
     ? ''
     : '?' + Object.keys(queryParams)
+        .filter(param => !! queryParams[param])
         .map(param => `${param}=${queryParams[param]}`)
         .join('&');
 
@@ -39,4 +40,10 @@ export const getCompleteQueryUrl = state => {
     return url +
       ( part[0] === '$' ? values[part] || '' : part )
   }, '') + queryString;
+}
+
+export const getRequestMethod = state => {
+  const endpoint = getSelectedEndpoint(state);
+
+  return endpoint ? endpoint.method : getMethod(state);
 }

--- a/src/state/results/actions.js
+++ b/src/state/results/actions.js
@@ -1,5 +1,5 @@
 import { REQUEST_RESULTS_RECEIVE } from '../actions';
-import { getMethod, getCompleteQueryUrl, getBodyParams } from '../request/selectors';
+import { getRequestMethod, getCompleteQueryUrl, getBodyParams } from '../request/selectors';
 import { getSelectedApi, getSelectedVersion } from '../ui/selectors';
 import { get } from '../../api';
 
@@ -14,7 +14,7 @@ export const request = () => (dispatch, getState) => {
   const state = getState();
   const apiName = getSelectedApi(state);
   const version = getSelectedVersion(state);
-  const method = getMethod(state);
+  const method = getRequestMethod(state);
   const path = getCompleteQueryUrl(state);
   const api = get(apiName);
   const body = getBodyParams(state);

--- a/src/state/results/actions.js
+++ b/src/state/results/actions.js
@@ -3,7 +3,16 @@ import { getRequestMethod, getCompleteQueryUrl, getBodyParams } from '../request
 import { getSelectedApi, getSelectedVersion } from '../ui/selectors';
 import { get } from '../../api';
 
+window.responses = [];
+const recordResponse = response => {
+  window.response = response;
+  window.responses.unshift(response);
+
+  console.log('%c window.response ready with ' + Object.keys(response).length + ' keys. Previous responses in window.responses[].', 'color: #cccccc;');
+};
+
 const receiveResults = (id, version, apiName, method, path, status, body, error, duration) => {
+  recordResponse({ version, apiName, method, path, status, body, error, duration });
   return {
     type: REQUEST_RESULTS_RECEIVE,
     payload: { id, version, apiName, method, path, status, body, error, duration }


### PR DESCRIPTION
 * Adding tooltips to display type and description on the query builder
<img width="1106" alt="capture d ecran 2016-10-27 a 10 19 37 am" src="https://cloud.githubusercontent.com/assets/272444/19761742/0874221c-9c2f-11e6-8e4b-dd93b16dd1ce.png">
 * Add surge deploy script
 * Fix the method used for requesting
 * Adding console logging