### PR TITLE
JSON Viewer : Show a preview of the content when collapsed

### DIFF
--- a/src/components/results/index.js
+++ b/src/components/results/index.js
@@ -7,27 +7,16 @@ import './style.css';
 
 import RequestHeader from './header';
 import { getResults } from '../../state/results/selectors';
+import { stringify } from './utils';
 
 const Results = ({ results }) => {
   const jsonTheme = {
-    scheme: 'bright',
-    author: 'chris kempson (http://chriskempson.com)',
-    base00: '#000000',
-    base01: '#303030',
-    base02: '#505050',
-    base03: '#b0b0b0',
-    base04: '#d0d0d0',
-    base05: '#e0e0e0',
-    base06: '#f5f5f5',
-    base07: '#ffffff',
-    base08: '#fb0120',
-    base09: '#fc6d24',
-    base0A: '#fda331',
-    base0B: '#a1c659',
-    base0C: '#76c7b7',
-    base0D: '#6fb3d2',
-    base0E: '#d381c3',
-    base0F: '#be643c'
+    extend: 'default',
+    nestedNodeItemString: (node, expandedNodes, type, expanded) => {
+      return {
+        className: expanded ? 'expanded' : 'collapsed'
+      };
+    }
   };
 
   return (
@@ -37,7 +26,15 @@ const Results = ({ results }) => {
           <RequestHeader request={ result.request } response={ result.response } />
           <div className="response">
             { !! result.response.body &&
-              <JSONTree theme={ jsonTheme } data={ result.response.body } shouldExpandNode={() => false} />
+              <JSONTree
+                theme={ jsonTheme }
+                data={ result.response.body }
+                shouldExpandNode={() => false}
+                getItemString={ (type, data, itemType, itemString) =>
+                  <span className="collapsed-content"
+                    dangerouslySetInnerHTML={{ __html: `${itemString} <span class="content">${stringify(data)}</span>` }} />
+                }
+              />
             }
           </div>
         </div>

--- a/src/components/results/style.css
+++ b/src/components/results/style.css
@@ -28,5 +28,36 @@
 }
 
 .response ul {
+  line-height: 18px;
+  font-family: monospace;
+  font-size: 13px;
   background: none !important;
+}
+
+.response li {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  white-space: nowrap;
+    color: rgb(92, 129, 21);
+}
+
+.collapsed-content {
+  display: inline;
+}
+
+.collapsed-content .key {
+  color: hsl(296,77%,32%);
+}
+
+.collapsed-content .string {
+  color: rgb(92, 129, 21);
+}
+
+.collapsed-content .number {
+  color: rgb(246, 103, 30);
+}
+
+.expanded .collapsed-content .content {
+  display: none;
 }

--- a/src/components/results/tests/utils.test.js
+++ b/src/components/results/tests/utils.test.js
@@ -1,0 +1,34 @@
+import { stringify } from '../utils';
+
+it('should stringify an object recursively', () => {
+  const object = {
+    'a': 'b',
+    'c': {
+      'd': 'e'
+    }
+  };
+  const expected = '{<span class="key">"a"</span>:<span class="string">"b"</span>, <span class="key">"c"</span>:{<span class="key">"d"</span>:<span class="string">"e"</span>}}';
+  expect(stringify(object)).toEqual(expected);
+});
+
+
+it('should stringify an array recursively', () => {
+  const object = [
+    'a',
+    'b',
+    ['c', 'd']
+  ];
+  const expected = '[<span class="key">"0"</span>:<span class="string">"a"</span>, <span class="key">"1"</span>:<span class="string">"b"</span>, <span class="key">"2"</span>:[<span class="key">"0"</span>:<span class="string">"c"</span>, <span class="key">"1"</span>:<span class="string">"d"</span>]]';
+  expect(stringify(object)).toEqual(expected);
+});
+
+it('should crop the output if we exceed max', () => {
+  const object = {
+    'a': 'b',
+    'c': {
+      'd': 'e'
+    }
+  };
+  const expected = '{<span class="key">"a"</span>:<span class="string">"b"</span> …}';
+  expect(stringify(object, 5)).toEqual(expected);
+});

--- a/src/components/results/utils.js
+++ b/src/components/results/utils.js
@@ -1,0 +1,47 @@
+import { isArray, isPlainObject, isString, toPairs } from 'lodash';
+
+const MAX_LENGTH = 60;
+
+const recursiveStringify = (data, max = MAX_LENGTH) => {
+  if (isPlainObject(data) || isArray(data)) {
+    const pairs = toPairs(data);
+
+    let output = isArray(data) ? '[' : '{';
+    let trailing = "";
+    let length = 1;
+    for(let [ key, value ] of pairs) {
+      output += trailing;
+      output += '<span class="key">"' + key + '"</span>:';
+      const recursion = recursiveStringify(value);
+      output += recursion.output;
+      length += key.toString().length + 2 + trailing.length + recursion.length;
+      trailing = ", ";
+      if (length > max) {
+        output += isArray(data) ? " …]" : " …}";
+        return {
+          length: length + 3,
+          output
+        }
+      }
+    }
+    return {
+      output: output + (isArray(data) ? "]" : "}"),
+      length: length + 1
+    };
+  }
+
+  if (isString(data)) {
+    return {
+      length: data.length + 2,
+      output: '<span class="string">"' + data.replace(/"/g, "\\\"") + '"</span>'
+    };
+  }
+
+  return {
+    length: data.toString().length,
+    output: '<span class="' + (typeof data) + '">' + data + '</span>'
+  };
+}
+
+export const stringify = (data, max = MAX_LENGTH) =>
+  recursiveStringify(data, max).output


### PR DESCRIPTION
Show a "preview" of the node's content when the node is collapsed like we do on the v2 console

<img width="937" alt="capture d ecran 2016-10-28 a 12 42 54 pm" src="https://cloud.githubusercontent.com/assets/272444/19805453/71fc6586-9d0c-11e6-9513-c53ccf3e1d5d.png">

@nylen