### PR TITLE
Keep Url/Query/Body Params between endpoint switches

### DIFF
--- a/src/state/request/reducer.js
+++ b/src/state/request/reducer.js
@@ -18,9 +18,6 @@ const reducer = (state = { method: 'GET', endpoint: false, pathValues: {}, url: 
       return {
         ...state,
         endpoint: action.payload.endpoint,
-        pathValues: {},
-        queryParams: {},
-        bodyParams: {},
         url: ''
       };
     case REQUEST_UPDATE_URL:

--- a/src/state/request/selectors.js
+++ b/src/state/request/selectors.js
@@ -4,13 +4,52 @@ export const getSelectedEndpoint = state => state.request.endpoint;
 
 export const getUrl = state => state.request.url;
 
-export const getPathValues = state => state.request.pathValues;
+export const getPathValues = state => {
+  const endpoint = getSelectedEndpoint(state);
+  if (! endpoint) {
+    return {};
+  }
+  const pathArgs = Object.keys(endpoint.request.path);
+
+  return pathArgs.reduce((ret, arg) => {
+     return {
+       ...ret,
+       [arg]: state.request.pathValues[arg]
+     };
+  }, {});
+};
 
 export const getMethod = state => state.request.method;
 
-export const getQueryParams = state => state.request.queryParams;
+export const getQueryParams = state => {
+  const endpoint = getSelectedEndpoint(state);
+  if (! endpoint) {
+    return {};
+  }
+  const queryArgs = Object.keys(endpoint.request.query);
 
-export const getBodyParams = state => state.request.bodyParams;
+  return queryArgs.reduce((ret, arg) => {
+     return {
+       ...ret,
+       [arg]: state.request.queryParams[arg]
+     };
+  }, {});
+};
+
+export const getBodyParams = state => {
+  const endpoint = getSelectedEndpoint(state);
+  if (! endpoint) {
+    return {};
+  }
+  const bodyArgs = Object.keys(endpoint.request.body);
+
+  return bodyArgs.reduce((ret, arg) => {
+     return {
+       ...ret,
+       [arg]: state.request.bodyParams[arg]
+     };
+  }, {});
+};
 
 export const getEndpointPathParts = state => {
   const endpoint = getSelectedEndpoint(state);

--- a/src/state/request/tests/reducer.test.js
+++ b/src/state/request/tests/reducer.test.js
@@ -52,9 +52,9 @@ it('should select a new endpoint and reset some params', () => {
   expect(reducer(state, action)).toEqual({
     endpoint: newEndpoint,
     method: 'GET',
-    queryParams: {},
-    bodyParams: {},
-    pathValues: {},
+    queryParams: { context: 'view' },
+    bodyParams: { a: 'b' },
+    pathValues: { $site: 'mySite' },
     url: ''
   });
 });

--- a/src/state/request/tests/selectors.test.js
+++ b/src/state/request/tests/selectors.test.js
@@ -30,12 +30,21 @@ it('getUrl should return the defined url', () => {
 });
 
 it('getPathValues should return the defined pathValues', () => {
-  const pathValues = { '$site': 'mysite' };
+  const pathValues = { '$site': 'mysite', 'toto': 'tata' };
   const state = {
-    request: { pathValues }
+    request: {
+      endpoint: {
+        request: {
+          path: {
+            $site: {}
+          }
+        }
+      },
+      pathValues
+    }
   };
 
-  expect(getPathValues(state)).toEqual(pathValues);
+  expect(getPathValues(state)).toEqual({ '$site': 'mysite' });
 });
 
 it('getMethod should return the selected method', () => {
@@ -48,21 +57,39 @@ it('getMethod should return the selected method', () => {
 });
 
 it('getQueryParams should return the defined queryParams', () => {
-  const queryParams = { 'context': 'view' };
+  const queryParams = { 'context': 'view', 'toto': 'tata'  };
   const state = {
-    request: { queryParams }
+    request: {
+      endpoint: {
+        request: {
+          query: {
+            context: {}
+          }
+        }
+      },
+      queryParams
+    }
   };
 
-  expect(getQueryParams(state)).toEqual(queryParams);
+  expect(getQueryParams(state)).toEqual({ 'context': 'view' });
 });
 
 it('getBodyParams should return the defined bodyParams', () => {
-  const bodyParams = { 'context': 'view' };
+  const bodyParams = { 'context': 'view', 'toto': 'tata' };
   const state = {
-    request: { bodyParams }
+    request: {
+      endpoint: {
+        request: {
+          body: {
+            context: {}
+          }
+        }
+      },
+      bodyParams
+    }
   };
 
-  expect(getBodyParams(state)).toEqual(bodyParams);
+  expect(getBodyParams(state)).toEqual({ 'context': 'view' });
 });
 
 it('getEndpointPathParts should explode the endpoint path correctly', () => {
@@ -87,7 +114,13 @@ describe('getCompleteQueryUrl', () => {
   it('should use the endpoint path, pathParts and queryParams if an endpoint is selected', () => {
     const state = {
       request: {
-        endpoint: { path_labeled: '/site/$site/posts/slug:$slug' },
+        endpoint: {
+          path_labeled: '/site/$site/posts/slug:$slug',
+          request: {
+            path: { $site: {}, $slug: {} },
+            query: { context: {}, page: {} }
+          }
+        },
         pathValues: {
           $site: 'testsite.wordpress.com',
           $slug: '10'


### PR DESCRIPTION
This mimic the current console behavior