### PR TITLE
Guess Arguments Types from the JSON Schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-input-autosize": "^1.1.0",
     "react-json-tree": "^0.10.0",
     "react-redux": "^4.4.5",
+    "react-tagsinput": "^3.13.6",
     "react-tooltip": "^3.2.1",
     "redux": "^3.6.0",
     "redux-thunk": "^2.1.0",

--- a/src/api/tests/core.test.js
+++ b/src/api/tests/core.test.js
@@ -1,54 +1,113 @@
 import { guessEndpointDocumentation, parseEndpoints } from '../core';
 
-it('Parse Core Endpoints', () => {
-  const discoveryData = {
-    namespace: 'wp/v2',
-    routes: {
-      '/wp/v2/sites/(?P<wpcom_site>[\w.:]+)/categories': {
-        namespace: 'wp/v2',
-        methods: ['GET','POST'],
-        endpoints:[
-          {
-            methods: ['GET'],
-            args:{
-              context:{
-                required: false,
-                'default': 'view',
-                enum: ['view','embed','edit'],
-                description: 'Scope under which the request is made; determines fields present in response.'
+describe('parseEndpoints', () => {
+  it('should parse the WP REST API discovery endpoint', () => {
+    const discoveryData = {
+      namespace: 'wp/v2',
+      routes: {
+        '/wp/v2/sites/(?P<wpcom_site>[\w.:]+)/categories': {
+          namespace: 'wp/v2',
+          methods: ['GET','POST'],
+          endpoints:[
+            {
+              methods: ['GET'],
+              args:{
+                context:{
+                  required: false,
+                  'default': 'view',
+                  enum: ['view','embed','edit'],
+                  description: 'Scope under which the request is made; determines fields present in response.'
+                }
+              }
+            }
+          ]
+        }
+      }
+    };
+
+    expect(parseEndpoints(discoveryData)).toEqual(
+      [
+        {
+          path_format: '/sites/%s/categories',
+          path_labeled: '/sites/$wpcom_site/categories',
+          request: {
+            body: [],
+            query: {
+              context: {
+                description: 'Scope under which the request is made; determines fields present in response.',
+                type: 'string'
+              }
+            },
+            path:{
+              $wpcom_site: {
+                description: '',
+                type: 'w.:'
+              }
+            }
+          },
+          description: 'List categories',
+          group: 'categories',
+          method: 'GET'
+        }
+      ]
+    );
+  });
+
+  it('should extract the types from the schema', () => {
+    const discoveryData = {
+      namespace: 'wp/v2',
+      routes: {
+        '/wp/v2/sites/(?P<wpcom_site>[\w.:]+)/categories': {
+          namespace: 'wp/v2',
+          methods: ['POST'],
+          endpoints:[
+            {
+              methods: ['POST'],
+              args:{
+                posts:{
+                  description: 'Posts related to this category'
+                }
+              }
+            }
+          ],
+          schema: {
+            properties: {
+              posts: {
+                type: 'array'
               }
             }
           }
-        ]
+        }
       }
-    }
-  };
+    };
 
-  expect(parseEndpoints(discoveryData)).toEqual(
-    [
-      {
-        path_format: '/sites/%s/categories',
-        path_labeled: '/sites/$wpcom_site/categories',
-        request: {
-          body: [],
-          query: {
-            context: {
-              description: 'Scope under which the request is made; determines fields present in response.'
+    expect(parseEndpoints(discoveryData)).toEqual(
+      [
+        {
+          path_format: '/sites/%s/categories',
+          path_labeled: '/sites/$wpcom_site/categories',
+          request: {
+            body: [],
+            query: {
+              posts: {
+                description: 'Posts related to this category',
+                type: 'array'
+              }
+            },
+            path:{
+              $wpcom_site: {
+                description: '',
+                type: 'w.:'
+              }
             }
           },
-          path:{
-            $wpcom_site: {
-              description: '',
-              type: 'w.:'
-            }
-          }
-        },
-        description: 'List categories',
-        group: 'categories',
-        method: 'GET'
-      }
-    ]
-  );
+          description: 'Create a category',
+          group: 'categories',
+          method: 'POST'
+        }
+      ]
+    );
+  });
 });
 
 describe('Guess Description', () => {

--- a/src/components/param-builder/index.js
+++ b/src/components/param-builder/index.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import TagsInput from 'react-tagsinput'
+import 'react-tagsinput/react-tagsinput.css';
 
 import './style.css';
 
@@ -20,9 +22,14 @@ const ParamBuilder = ({ title, params, values = {}, onChange }) => {
                       <th>{ paramKey }</th>
                       <td>
                         <div>
-                          <input type="text" value={ values[paramKey] || '' }
-                            data-tip data-for={ `param-${paramKey}` }
-                            onChange={ event => onChange(paramKey, event.target.value) } />
+                          { parameter.type === 'array'
+                              ? <TagsInput value={ values[paramKey] || [] }
+                                  inputProps={ { placeholder: 'Add a value', 'data-tip': true, 'data-for': `param-${paramKey}` } }
+                                  onChange={ value => onChange(paramKey, value) } />
+                                : <input type="text" value={ values[paramKey] || '' }
+                                  data-tip data-for={ `param-${paramKey}` }
+                                  onChange={ event => onChange(paramKey, event.target.value) } />
+                          }
                           <ParamTooltip parameter={ parameter } id={ `param-${paramKey}` } name={paramKey} position="right" />
                         </div>
                       </td>

--- a/src/components/param-builder/style.css
+++ b/src/components/param-builder/style.css
@@ -65,3 +65,21 @@
 .param-builder td input:focus {
   outline: none;
 }
+
+.param-builder .react-tagsinput {
+  border: none;
+  padding: 0;
+}
+
+.param-builder .react-tagsinput input {
+  width: auto;
+  margin: 0;
+}
+
+.param-builder .react-tagsinput-tag {
+  margin-right: 0;
+  margin-left: 5px;
+  color: hsl(202,68%,44%);
+  background: hsl(205,38%,94%);
+  border-color: hsl(202,68%,44%);
+}

--- a/src/components/results/index.js
+++ b/src/components/results/index.js
@@ -7,7 +7,7 @@ import './style.css';
 
 import RequestHeader from './header';
 import { getResults } from '../../state/results/selectors';
-import { stringify } from './utils';
+import { stringify } from './utils';
 
 const Results = ({ results }) => {
   const jsonTheme = {

--- a/src/components/results/utils.js
+++ b/src/components/results/utils.js
@@ -1,4 +1,4 @@
-import { isArray, isPlainObject, isString, toPairs } from 'lodash';
+import { isArray, isPlainObject, isString, toPairs, toString } from 'lodash';
 
 const MAX_LENGTH = 60;
 
@@ -38,7 +38,7 @@ const recursiveStringify = (data, max = MAX_LENGTH) => {
   }
 
   return {
-    length: data.toString().length,
+    length: toString(data).length,
     output: '<span class="' + (typeof data) + '">' + data + '</span>'
   };
 }

--- a/src/state/request/selectors.js
+++ b/src/state/request/selectors.js
@@ -1,4 +1,4 @@
-import { compact } from 'lodash';
+import { compact, isArray } from 'lodash';
 
 export const getSelectedEndpoint = state => state.request.endpoint;
 
@@ -70,11 +70,19 @@ export const getCompleteQueryUrl = state => {
   const parts = getEndpointPathParts(state);
   const values = getPathValues(state);
   const queryParams = getQueryParams(state);
+  const buildParamUrl = (param, value) => {
+    if (isArray(value)) {
+      return value.map(subvalue => `${param}[]=${subvalue}`)
+        .join('&');
+    }
+
+    return `${param}=${value}`;
+  }
   const queryString = Object.keys(queryParams).length === 0
     ? ''
     : '?' + Object.keys(queryParams)
         .filter(param => !! queryParams[param])
-        .map(param => `${param}=${queryParams[param]}`)
+        .map(param => buildParamUrl(param, queryParams[param]))
         .join('&');
 
   return parts.reduce((url, part) => {


### PR DESCRIPTION
For Arrays, show a tags input instead of a classic text input

<img width="613" alt="capture d ecran 2016-10-31 a 5 55 02 pm" src="https://cloud.githubusercontent.com/assets/272444/19863134/57eabe3e-9f93-11e6-9915-97ee6f07a2a9.png">

This is the first attempt to use the JSON schema of the endpoints to extract the arg types. 
See https://github.com/Automattic/io/issues/635

We could imagine adding some validation based on types (numeric, string etc...). For Arrays, it can be handy to have the type of the items as well (However, not required to fix the Query Building of array args)

cc @nylen

I can backport this to the V2 console if required