### PR TITLE
Add uniform width to methods to increase readability

### DIFF
--- a/src/components/endpoint-selector/index.js
+++ b/src/components/endpoint-selector/index.js
@@ -35,7 +35,7 @@ class EndpointSelector extends Component {
 
     return endpoints.map((endpoint, index) =>
       <li key={ index } onClick={ () => onSelect(endpoint) }>
-        <span>{ endpoint.method }</span>
+        <span className="method">{ endpoint.method }</span>
         <code>{ endpoint.path_labeled }</code>
         <strong>{ endpoint.group }</strong>
         <em>{ endpoint.description }</em>

--- a/src/components/endpoint-selector/style.css
+++ b/src/components/endpoint-selector/style.css
@@ -57,7 +57,7 @@
 
 .endpoint-selector li > span.method {
   display: inline-block;
-  width: 40px;
+  width: 56px;
 }
 
 .endpoint-selector li > em, .endpoint-selector li > strong {

--- a/src/components/endpoint-selector/style.css
+++ b/src/components/endpoint-selector/style.css
@@ -55,6 +55,11 @@
   width: 45px;
 }
 
+.endpoint-selector li > span.method {
+  display: inline-block;
+  width: 40px;
+}
+
 .endpoint-selector li > em, .endpoint-selector li > strong {
   font-size: 14px;
   font-weight: 100;


### PR DESCRIPTION
Quick change to make the list of endpoints a bit easier to read.

__Before__
![wordpress_console](https://cloud.githubusercontent.com/assets/22080/20022340/3958fa42-a297-11e6-9b21-f1673f9aad4c.png)

__After__
![wordpress_console](https://cloud.githubusercontent.com/assets/22080/20022354/4b86101a-a297-11e6-8ee6-1e4a22b917d6.png)
