### PR TITLE
Only keep one endpoint copy in history.

### DIFF
--- a/src/state/history/reducer.js
+++ b/src/state/history/reducer.js
@@ -1,12 +1,19 @@
 import { createReducer } from '../../lib/redux/create-reducer';
 import { REQUEST_SELECT_ENDPOINT } from '../actions';
 import schema from './schema';
+import find from 'lodash/find';
 
 const MAX_HISTORY_ENDPOINTS = 10;
 
 const reducer = createReducer({}, {
   [REQUEST_SELECT_ENDPOINT]: (state, { payload: { apiName, version, endpoint } }) => {
     if (! endpoint) {
+      return state;
+    }
+
+    if ( state[apiName] &&
+          state[apiName][version] &&
+          find( state[apiName][version], { 'path_labeled': endpoint.path_labeled } ) ) {
       return state;
     }
 

--- a/src/state/history/reducer.js
+++ b/src/state/history/reducer.js
@@ -1,7 +1,7 @@
 import { createReducer } from '../../lib/redux/create-reducer';
 import { REQUEST_SELECT_ENDPOINT } from '../actions';
 import schema from './schema';
-import find from 'lodash/find';
+import filter from 'lodash/filter';
 
 const MAX_HISTORY_ENDPOINTS = 10;
 
@@ -10,11 +10,12 @@ const reducer = createReducer({}, {
     if (! endpoint) {
       return state;
     }
+    let currentEndpoints = [];
 
-    if ( state[apiName] &&
-          state[apiName][version] &&
-          find( state[apiName][version], { 'path_labeled': endpoint.path_labeled } ) ) {
-      return state;
+    if ( state[apiName] && state[apiName][version] ) {
+      currentEndpoints = filter( state[apiName][version], ( existingEndpoint ) => {
+        return existingEndpoint.path_labeled !== endpoint.path_labeled;
+      } );
     }
 
     return {
@@ -23,7 +24,7 @@ const reducer = createReducer({}, {
         ...state[apiName],
         [version]: [
           endpoint,
-          ...(state[apiName] && state[apiName][version] ? state[apiName][version] : [])
+          ...currentEndpoints
         ].slice(0, MAX_HISTORY_ENDPOINTS)
       }
     };

--- a/src/state/history/tests/reducer.test.js
+++ b/src/state/history/tests/reducer.test.js
@@ -75,7 +75,6 @@ it('should merge endpoints for the same api and version', () => {
 });
 
 it('should not merge duplicate endpoints for the same api and version', () => {
-  const newEndpoint = { path_labeled: 'mynewEndpoint' };
   const action = {
     type: REQUEST_SELECT_ENDPOINT,
     payload: {
@@ -88,6 +87,29 @@ it('should not merge duplicate endpoints for the same api and version', () => {
   expect(reducer(state, action)).toEqual({
     wpcom: {
       v1: [ endpoint ]
+    }
+  });
+});
+
+it('should put duplicate endpoints at the front of the history', () => {
+  const newEndpoint = { path_labeled: 'mynewEndpoint' };
+  const state2 = deepFreeze({
+    wpcom: {
+      v1: [ newEndpoint, endpoint ]
+    }
+  });
+  const action = {
+    type: REQUEST_SELECT_ENDPOINT,
+    payload: {
+      apiName: 'wpcom',
+      version: 'v1',
+      endpoint: endpoint
+    }
+  };
+
+  expect(reducer(state2, action)).toEqual({
+    wpcom: {
+      v1: [ endpoint, newEndpoint ]
     }
   });
 });

--- a/src/state/history/tests/reducer.test.js
+++ b/src/state/history/tests/reducer.test.js
@@ -73,3 +73,21 @@ it('should merge endpoints for the same api and version', () => {
     }
   });
 });
+
+it('should not merge duplicate endpoints for the same api and version', () => {
+  const newEndpoint = { path_labeled: 'mynewEndpoint' };
+  const action = {
+    type: REQUEST_SELECT_ENDPOINT,
+    payload: {
+      apiName: 'wpcom',
+      version: 'v1',
+      endpoint: endpoint
+    }
+  };
+
+  expect(reducer(state, action)).toEqual({
+    wpcom: {
+      v1: [ endpoint ]
+    }
+  });
+});


### PR DESCRIPTION
I noticed while testing that each time I clicked on an endpoint in the lookup tool, it was adding it to my "Recent" history.  Which is really nice, but when clicking the same endpoint multiple times, things look like this:

![wordpress_console 3](https://cloud.githubusercontent.com/assets/22080/20023012/8485957c-a29a-11e6-9ff8-33efa75148c2.png)

This change adds logic to the reducer to not add an item to history if it already exists for that api/version combo:

![wordpress_console 2](https://cloud.githubusercontent.com/assets/22080/20023031/9ba615b0-a29a-11e6-9709-801ee87cde80.png)

