### PR TITLE
Add/basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ You will also need to add your host to the CORS whitelist in the Application's s
 ```json
 {
   "wordpress.com": {
-    "client_id": "33333",
-    "redirect_uri": "http://localhost:3000"
+    "clientID": "33333",
+    "redirectUrl": "http://localhost:3000"
   }
 }
 ```
@@ -45,17 +45,17 @@ You can also use this console with your WordPress.org installation but make sure
 {
   "wordpress.org": [
     {
-      "name": "Dev",  // Name to display on the API selector
-      "url": "http://src.wordpress-develop.dev", // Base URL of your WordPress website
-      "publicKey": "PwQXbJdBYrXq", // Public Key of your application
-      "secretKey": "XB9oidFfxr3guKhFcSOvwOamFlOQnauPbEcN6krtKix9MBVb", // Secrent Key of your application
-      "callbackUrl": "http://localhost:3000" // Callback URL: should reflect the public url of the console
+      "name": "Dev",                         // Name to display on the API selector
+      "url": "http://wordpress.dev",         // Base URL of your WordPress website
+      "clientKey": "PwQXbJdBYrXq",           // Client (public) key of your application
+      "secretKey": "XB9oidFfxr3g...",        // Secret key of your application
+      "callbackUrl": "http://localhost:3000" // Callback URL where you are running this console
     }
   ]
 }
 ```
 
-Note that your application should not be on `localhost` to work.
+Note that your console should not be running on `localhost` to work: the OAuth1 plugin prohibits local URLs by default.
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,32 @@ You can also use this console with your WordPress.org installation but make sure
 
 Note that your console should not be running on `localhost` to work: the OAuth1 plugin prohibits local URLs by default.
 
+You can also install the
+[Application Passwords plugin](https://github.com/georgestephanis/application-passwords/)
+and use basic authentication to communicate with your site.  Make sure that
+your site is running over https, otherwise this is insecure.  Here are the
+config settings for basic auth:
+
+```javascript
+{
+  "wordpress.org": [
+    {
+      "name": "Dev (basic)",                 // Name to display on the API selector
+      "url": "http://wordpress.dev",         // Base URL of your WordPress website
+      "authType": "basic",
+      "authHeader": "Basic bWU6bXlwYSBzc3dvIHJk"
+    }
+  ]
+}
+```
+
+You can generate the base64-encoded portion of the `authHeader` as follows:
+
+```sh
+$ echo -n 'me:mypa sswo rd' | base64
+bWU6bXlwYSBzc3dvIHJk
+```
+
 ## Building
 
 To create a static package you can use anywhere (e.g. Github pages): `npm run build`

--- a/src/auth/basic.js
+++ b/src/auth/basic.js
@@ -1,0 +1,67 @@
+import superagent from 'superagent';
+
+const createBasicAuthProvider = (name, baseUrl, authHeader) => {
+	const boot = () => {
+    if (!authHeader) {
+      return Promise.reject();
+    }
+
+    const userUrl = `${baseUrl}/wp-json/wp/v2/users/me?_envelope`;
+
+    return superagent
+      .get(userUrl)
+      .set('accept', 'application/json')
+      .set('Authorization', authHeader)
+      .then(res => {
+				const user = res.body.body;
+				return {
+					...user,
+					avatar_URL: user.avatar_urls ? Object.values(user.avatar_urls)[0] : ''
+				};
+			});
+	};
+
+	const login = () => {
+		if (!authHeader) {
+			return Promise.reject('Basic auth header is not set');
+		}
+
+		return Promise.resolve();
+	};
+
+  const request = ({ method, url, body }) => {
+    const req = superagent(method, url)
+      .set('accept', 'application/json');
+
+    if (body && Object.keys(body).length > 0) {
+      req.send(body);
+    }
+
+		req.set('Authorization', authHeader);
+
+    return new Promise(resolve =>
+      req.end((err, response = {}) => {
+        let error = err;
+        if (err && response.body && response.body.error) {
+          error = response.body.error;
+        } else if (err && response.error) {
+          error = response.error.message;
+        }
+
+        resolve({
+          status: response.status,
+          body: response.body,
+          error
+        });
+      })
+    );
+  };
+
+  const logout = () => {};
+
+  return {
+    boot, login, logout, request
+  };
+};
+
+export default createBasicAuthProvider;

--- a/src/auth/oauth1.js
+++ b/src/auth/oauth1.js
@@ -3,7 +3,7 @@ import querystring from 'querystring';
 import OAuth from 'oauth-1.0a';
 import crypto from 'crypto';
 
-const createOauth1Provider = (name, baseUrl, callbackURL, publicKey, secretKey) => {
+const createOauth1Provider = (name, baseUrl, callbackUrl, publicKey, secretKey) => {
   const TOKEN_STORAGE_KEY = `${name}__OAUTH1CCESSTOKEN`;
   const REQUEST_TOKEN_STORAGE_KEY = `${name}__REQUESTOAUTH1CCESSTOKEN`;
 
@@ -75,17 +75,17 @@ const createOauth1Provider = (name, baseUrl, callbackURL, publicKey, secretKey) 
   }
 
   const login = () => {
-    const requestUrl = `${baseUrl}/oauth1/request?callback_url=${callbackURL}`;
+    const requestUrl = `${baseUrl}/oauth1/request?callback_url=${callbackUrl}`;
     oauthRequest('POST', requestUrl)
       .then(({ body }) => {
         localStorage.setItem(REQUEST_TOKEN_STORAGE_KEY, JSON.stringify({
   				secret: body.oauth_token_secret,
   			}));
-        const redirectURL = baseUrl + '/oauth1/authorize?' + querystring.stringify({
+        const redirectUrl = baseUrl + '/oauth1/authorize?' + querystring.stringify({
   				oauth_token: body.oauth_token,
-  				oauth_callback: callbackURL,
+					oauth_callback: callbackUrl,
   			});
-        window.location = redirectURL;
+        window.location = redirectUrl;
       });
   }
 


### PR DESCRIPTION
Add a basic auth provider for use with the [Application Passwords plugin](https://github.com/georgestephanis/application-passwords/).

Also standardize some config keys and variable names:

- WP.com: `client_id` → `clientID`
- WP.com: `redirect_uri` → `redirectUrl`
- WP.org: `publicKey` → `clientKey` (matches the terminology used in the plugin) 