### PR TITLE
Fix trailing slashes in OAuth1 site URLs

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -41,7 +41,8 @@ if (config['wordpress.org']) {
   APIs = APIs.concat(
     config['wordpress.org'].map(site => {
       let authProvider;
-      const { name, url, authType } = site;
+      const { name, authType } = site;
+      let url = site.url.replace(/\/+$/, '');
       if ( authType === 'basic' ) {
         authProvider = createBasicAuthProvider(name, url, site.authHeader);
       } else { // OAuth1


### PR DESCRIPTION
This was causing invalid API URLs like `wp-json//wp/v2`.